### PR TITLE
Add repository link and readme

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 authors = ["Jack Wrenn <me@jswrenn.com>"]
 license = "MIT"
 description = "type-level layout reflection"
+repository = "https://github.com/jswrenn/typelayout"
+readme = "README.md"
 edition = "2018"
 
 [dependencies]


### PR DESCRIPTION
Thanks for the awesome crate! I noticed the lack of a link back to the repo on docs.rs. This PR fixes that :).

Adds a link back to the repo on docs.rs and crates.io, and renders the README on crates.io.